### PR TITLE
Mainnet deployment v1.0.0 configuration

### DIFF
--- a/deploy/deployment_manifest.json
+++ b/deploy/deployment_manifest.json
@@ -24,7 +24,20 @@
         "interestRatePerBlock": "12089063975",
         "pausedSinceBlock": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         "lockPeriodInBlocks": "30",
-        "description:": "Above value of `interestRatePerBlock` is calculated from form Annual Percentage Rate 10 [%/Year] for Kovan network using anticipated aver. block duration 4[s/Block] => 7884000 [Block/Year]."
+        "description:": "Above value of `interestRatePerBlock` is calculated from Annual Percentage Rate 10 [%/Year] for Kovan network using anticipated aver. block duration 4[s/Block] => 7884000 [Block/Year]."
+      }
+    }
+  },
+  "mainnet": {
+    "Staking": {
+      "contract_address": "",
+      "constructor_params": {
+        "ERC20Address": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85",
+        "interestRatePerBlock": "39803243689",
+        "pausedSinceBlock": "0",
+        "lockPeriodInBlocks": "137767",
+        "description_interestRatePerBlock": "Value 39803243689 [ContractUnit] is calculated from Annual Percentage Rate(APR) = 10 [%/Year] for MAINNET network using anticipated aver. block duration 13.17[s/Block] ==> aver. blocks per year = 2394533.0296... [Block] = 365*24*60*60[s] / 13.17[s/Block],  using following analytical formula: interestRatePerBlock = (1 + APR/(100[%]))**(1/BLOCKS_PER_ANNUM) - 1 [1] = (1 + 0.1)**(1 / 2394533) - 1 [1] = 3.98032436898836850380326931132062565160333e-8 [1] = 39803243689.8836850380326931132062565160333 [ContractUnit] = {TRIMMED} 39803243689 [ContractUnit], where [ContractUnit] = 1e-18 [1] = 1e-16 [%]",
+        "description_lockPeriodInBlocks": "Value 137767 [Block] is calculated from 21[Day] locking period using following formula: lockPeriodInBlocks = lock_period_in[s] / aver_block_duration[s/Block] = 21*24*60*60[s] / 13.17[s/Block] = 137767.653...[Block] = {TRUNCATED} 137767[Block], where the aver_block_duration = 13.17[s/Block] as assumed above"
       }
     }
   }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -87,7 +87,7 @@ module.exports = {
 
     mainnet: {
       provider: () => {
-          let mnemonic = fs.readFileSync(`${dir}/.secrets_mnemonic_kovan`).toString().trim();
+          let mnemonic = fs.readFileSync(`${dir}/.secrets_mnemonic_mainnet`).toString().trim();
           let infuraProjectId = fs.readFileSync(`${dir}/.secrets_infura_project_id`).toString().trim();
           const _endpoint = `https://mainnet.infura.io/v3`;
           //const _endpoint = 'wss://mainnet.infura.io/ws/v3';

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -84,6 +84,27 @@ module.exports = {
       gasPrice: 10000000000,
       //websockets: true
     },
+
+    mainnet: {
+      provider: () => {
+          let mnemonic = fs.readFileSync(`${dir}/.secrets_mnemonic_kovan`).toString().trim();
+          let infuraProjectId = fs.readFileSync(`${dir}/.secrets_infura_project_id`).toString().trim();
+          const _endpoint = `https://mainnet.infura.io/v3`;
+          //const _endpoint = 'wss://mainnet.infura.io/ws/v3';
+          let endpoint = `${_endpoint}/${infuraProjectId}`;
+          console.log(`endpoint = "${endpoint}"`);
+          const provider = new HDWalletProvider(mnemonic, endpoint, 0, 10, true);
+          mnemonic = null;
+          infuraProjectId = null;
+          provider.host = endpoint;
+          //endpoint = null;
+          return provider;
+        },
+      network_id: 1,
+      gas: 12000000,
+      gasPrice: 75000000000,
+      //websockets: true
+    },
   },
 
   //// Set default mocha options here, use special reporters etc.

--- a/utility/utils.js
+++ b/utility/utils.js
@@ -63,8 +63,9 @@ exports.sleep = function (ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-exports.logGasUsed = function (tx_receipt) {
-    console.log("gasUsed = " + tx_receipt.receipt.gasUsed);
+exports.logGasUsed = function (tx_receipt, methodName=null) {
+    const methodDesc = methodName ? `${methodName}(...)` : "";
+    console.log(`gasUsed ${methodDesc}: ${tx_receipt.receipt.gasUsed}`);
     return tx_receipt;
 }
 


### PR DESCRIPTION
This change carries configuration for v1.0.0 mainent deployment for the Staking.sol contract.

Configuration is stored in the `deploy/deployment_manifest.json` file in the `mainnet` section - please focus this section and all values provided there.

The configuration carries following (as described in `description_...` keys in the manifest json file):
1. Average block time:  13.17 [s/Block] which was derived from data fetched from the https://etherscan.io/chart/blocktime (using linear extrapoation of this year data by adjusting proportionally by data from the last year for the same poeriod of the year)

2. Aver Number of Blocks per year: 2394533 [Block] derived from Average block time defined above

3. **Contract will be PAUSED** at the point of deployment (see the `pausedSinceBlock` in the json file)

4. **Interest Rate** of the contract is set to equivalet of **Annual Percentage Rate(APR) = 10[%]** - please see the `interestRatePerBlock` in the json file as well as associated description in the `description_interestRatePerBlock` detailing how exactly was the conract value calculated

5. **Locking Period** has been set to **equivalent of 21 days** - please see the `lockPeriodInBlocks` and associated `description_lockPeriodInBlocks` in the json file